### PR TITLE
Test: Add test for date & sort utils

### DIFF
--- a/src/utils/sort.ts
+++ b/src/utils/sort.ts
@@ -22,7 +22,7 @@ export const descendingBubbleSort = (arr: number[]): number[] => {
   for (let i = 0; i < result.length; i++) {
     for (let j = result.length - 1; j > i; j--) {
       if (result[j] > result[j - 1]) {
-        const value = arr[j];
+        const value = result[j];
         result[j] = result[j - 1];
         result[j - 1] = value;
       }

--- a/src/utils/test/date.test.ts
+++ b/src/utils/test/date.test.ts
@@ -1,0 +1,25 @@
+import { LOCALE } from 'utils/constants';
+import { getLocaleDate, getLocaleTime } from 'utils/date';
+
+describe('Locale 날짜/시간 테스트', () => {
+  test('Locale 한국 날짜 테스트', () => {
+    expect(getLocaleDate(new Date('2021-10-13'), LOCALE.koKR)).toBe(
+      '2021년 10월 13일 수요일',
+    );
+  });
+  test('Locale 미국 날짜 테스트', () => {
+    expect(getLocaleDate(new Date('2021-10-13'), LOCALE.enUS)).toBe(
+      'Wednesday, October 13, 2021',
+    );
+  });
+  test('Locale 한국 시간 테스트', () => {
+    expect(getLocaleTime(new Date('2021-10-13 13:49:25'), LOCALE.koKR)).toBe(
+      '오후 1:49:25',
+    );
+  });
+  test('Locale 미국 시간 테스트', () => {
+    expect(getLocaleTime(new Date('2021-10-13 13:49:25'), LOCALE.enUS)).toBe(
+      '1:49:25 PM',
+    );
+  });
+});

--- a/src/utils/test/sort.test.ts
+++ b/src/utils/test/sort.test.ts
@@ -1,0 +1,26 @@
+import { ascendingBubbleSort, descendingBubbleSort } from 'utils/sort';
+
+describe('버블정렬 테스트', () => {
+  test('오름차순 정렬 테스트', () => {
+    expect(ascendingBubbleSort([8, 3, 5, 1, 0])).toEqual([0, 1, 3, 5, 8]);
+  });
+  test('음수 포함 오름차순 정렬 테스트', () => {
+    expect(ascendingBubbleSort([8, 3, -5, 1, 0])).toEqual([-5, 0, 1, 3, 8]);
+  });
+  test('소수 포함 오름차순 정렬 테스트', () => {
+    expect(ascendingBubbleSort([8, 3, 5, 1, 0, 3.7])).toEqual([
+      0, 1, 3, 3.7, 5, 8,
+    ]);
+  });
+  test('내림차순 정렬 테스트', () => {
+    expect(descendingBubbleSort([8, 3, 5, 1, 0])).toEqual([8, 5, 3, 1, 0]);
+  });
+  test('음수 포함 내림차순 정렬 테스트', () => {
+    expect(descendingBubbleSort([8, -3, 5, 1, 0])).toEqual([8, 5, 1, 0, -3]);
+  });
+  test('소수 포함 내림차순 정렬 테스트', () => {
+    expect(descendingBubbleSort([8, 3, 5, 5.6, 1, 0])).toEqual([
+      8, 5.6, 5, 3, 1, 0,
+    ]);
+  });
+});


### PR DESCRIPTION
테스트 경험을 위해 jest를 이용해 util 함수 테스트 작성
- locale date & time 관련 테스트 작성
- bubble sort 관련 테스트 작성
- 참고: https://jestjs.io/
  - [toBe(value)](https://jestjs.io/docs/expect#tobevalue): primitive 값 또는 object의 참조를 비교
  - [toEqual(value)](https://jestjs.io/docs/expect#toequalvalue): object의 모든 property를 재귀적으로 비교

버블 정렬 테스트 중 내림차순 정렬에서 버그 발견 및 수정
- 정렬 시 일부 구간에서 복사한 배열 대신 원본 배열을 사용해 제대로 정렬되지 않는 버그 발견
- 복사한 배열을 사용하도록 수정